### PR TITLE
[SQUASH] bootanimation: Revert GLES v2 implementation with dynamic co…

### DIFF
--- a/cmds/bootanimation/Android.bp
+++ b/cmds/bootanimation/Android.bp
@@ -71,7 +71,7 @@ cc_library_shared {
         "libui",
         "libjnigraphics",
         "libEGL",
-        "libGLESv2",
+        "libGLESv1_CM",
         "libgui",
     ],
 }

--- a/cmds/bootanimation/BootAnimation.cpp
+++ b/cmds/bootanimation/BootAnimation.cpp
@@ -52,8 +52,9 @@
 #include <gui/DisplayEventReceiver.h>
 #include <gui/Surface.h>
 #include <gui/SurfaceComposerClient.h>
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
+
+#include <GLES/gl.h>
+#include <GLES/glext.h>
 #include <EGL/eglext.h>
 
 #include "BootAnimation.h"
@@ -108,93 +109,6 @@ static const char DISPLAYS_PROP_NAME[] = "persist.service.bootanim.displays";
 static const char CLOCK_ENABLED_PROP_NAME[] = "persist.sys.bootanim.clock.enabled";
 static const int ANIM_ENTRY_NAME_MAX = ANIM_PATH_MAX + 1;
 static constexpr size_t TEXT_POS_LEN_MAX = 16;
-static const int DYNAMIC_COLOR_COUNT = 4;
-static const char U_TEXTURE[] = "uTexture";
-static const char U_FADE[] = "uFade";
-static const char U_CROP_AREA[] = "uCropArea";
-static const char U_START_COLOR_PREFIX[] = "uStartColor";
-static const char U_END_COLOR_PREFIX[] = "uEndColor";
-static const char U_COLOR_PROGRESS[] = "uColorProgress";
-static const char A_UV[] = "aUv";
-static const char A_POSITION[] = "aPosition";
-static const char VERTEX_SHADER_SOURCE[] = R"(
-    precision mediump float;
-    attribute vec4 aPosition;
-    attribute highp vec2 aUv;
-    varying highp vec2 vUv;
-    void main() {
-        gl_Position = aPosition;
-        vUv = aUv;
-    })";
-static const char IMAGE_FRAG_DYNAMIC_COLORING_SHADER_SOURCE[] = R"(
-    precision mediump float;
-    const float cWhiteMaskThreshold = 0.05;
-    uniform sampler2D uTexture;
-    uniform float uFade;
-    uniform float uColorProgress;
-    uniform vec3 uStartColor0;
-    uniform vec3 uStartColor1;
-    uniform vec3 uStartColor2;
-    uniform vec3 uStartColor3;
-    uniform vec3 uEndColor0;
-    uniform vec3 uEndColor1;
-    uniform vec3 uEndColor2;
-    uniform vec3 uEndColor3;
-    varying highp vec2 vUv;
-    void main() {
-        vec4 mask = texture2D(uTexture, vUv);
-        float r = mask.r;
-        float g = mask.g;
-        float b = mask.b;
-        float a = mask.a;
-        // If all channels have values, render pixel as a shade of white.
-        float useWhiteMask = step(cWhiteMaskThreshold, r)
-            * step(cWhiteMaskThreshold, g)
-            * step(cWhiteMaskThreshold, b)
-            * step(cWhiteMaskThreshold, a);
-        vec3 color = r * mix(uStartColor0, uEndColor0, uColorProgress)
-                + g * mix(uStartColor1, uEndColor1, uColorProgress)
-                + b * mix(uStartColor2, uEndColor2, uColorProgress)
-                + a * mix(uStartColor3, uEndColor3, uColorProgress);
-        color = mix(color, vec3((r + g + b + a) * 0.25), useWhiteMask);
-        gl_FragColor = vec4(color.x, color.y, color.z, (1.0 - uFade));
-    })";
-static const char IMAGE_FRAG_SHADER_SOURCE[] = R"(
-    precision mediump float;
-    uniform sampler2D uTexture;
-    uniform float uFade;
-    varying highp vec2 vUv;
-    void main() {
-        vec4 color = texture2D(uTexture, vUv);
-        gl_FragColor = vec4(color.x, color.y, color.z, (1.0 - uFade)) * color.a;
-    })";
-static const char TEXT_FRAG_SHADER_SOURCE[] = R"(
-    precision mediump float;
-    uniform sampler2D uTexture;
-    uniform vec4 uCropArea;
-    varying highp vec2 vUv;
-    void main() {
-        vec2 uv = vec2(mix(uCropArea.x, uCropArea.z, vUv.x),
-                       mix(uCropArea.y, uCropArea.w, vUv.y));
-        gl_FragColor = texture2D(uTexture, uv);
-    })";
-
-static GLfloat quadPositions[] = {
-    -0.5f, -0.5f,
-    +0.5f, -0.5f,
-    +0.5f, +0.5f,
-    +0.5f, +0.5f,
-    -0.5f, +0.5f,
-    -0.5f, -0.5f
-};
-static GLfloat quadUVs[] = {
-    0.0f, 1.0f,
-    1.0f, 1.0f,
-    1.0f, 0.0f,
-    1.0f, 0.0f,
-    0.0f, 0.0f,
-    0.0f, 1.0f
-};
 
 // ---------------------------------------------------------------------------
 
@@ -250,8 +164,7 @@ void BootAnimation::binderDied(const wp<IBinder>&) {
     requestExit();
 }
 
-static void* decodeImage(const void* encodedData, size_t dataLength, AndroidBitmapInfo* outInfo,
-    bool premultiplyAlpha) {
+static void* decodeImage(const void* encodedData, size_t dataLength, AndroidBitmapInfo* outInfo) {
     AImageDecoder* decoder = nullptr;
     AImageDecoder_createFromBuffer(encodedData, dataLength, &decoder);
     if (!decoder) {
@@ -264,10 +177,6 @@ static void* decodeImage(const void* encodedData, size_t dataLength, AndroidBitm
     outInfo->format = AImageDecoderHeaderInfo_getAndroidBitmapFormat(info);
     outInfo->stride = AImageDecoder_getMinimumStride(decoder);
     outInfo->flags = 0;
-
-    if (!premultiplyAlpha) {
-        AImageDecoder_setUnpremultipliedRequired(decoder, true);
-    }
 
     const size_t size = outInfo->stride * outInfo->height;
     void* pixels = malloc(size);
@@ -282,14 +191,13 @@ static void* decodeImage(const void* encodedData, size_t dataLength, AndroidBitm
 }
 
 status_t BootAnimation::initTexture(Texture* texture, AssetManager& assets,
-        const char* name, bool premultiplyAlpha) {
+        const char* name) {
     Asset* asset = assets.open(name, Asset::ACCESS_BUFFER);
     if (asset == nullptr)
         return NO_INIT;
 
     AndroidBitmapInfo bitmapInfo;
-    void* pixels = decodeImage(asset->getBuffer(false), asset->getLength(), &bitmapInfo,
-        premultiplyAlpha);
+    void* pixels = decodeImage(asset->getBuffer(false), asset->getLength(), &bitmapInfo);
     auto pixelDeleter = std::unique_ptr<void, decltype(free)*>{ pixels, free };
 
     asset->close();
@@ -302,6 +210,7 @@ status_t BootAnimation::initTexture(Texture* texture, AssetManager& assets,
     const int w = bitmapInfo.width;
     const int h = bitmapInfo.height;
 
+    GLint crop[4] = { 0, h, w, -h };
     texture->w = w;
     texture->h = h;
 
@@ -329,19 +238,18 @@ status_t BootAnimation::initTexture(Texture* texture, AssetManager& assets,
             break;
     }
 
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_CROP_RECT_OES, crop);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
     return NO_ERROR;
 }
 
-status_t BootAnimation::initTexture(FileMap* map, int* width, int* height,
-    bool premultiplyAlpha) {
+status_t BootAnimation::initTexture(FileMap* map, int* width, int* height) {
     AndroidBitmapInfo bitmapInfo;
-    void* pixels = decodeImage(map->getDataPtr(), map->getDataLength(), &bitmapInfo,
-        premultiplyAlpha);
+    void* pixels = decodeImage(map->getDataPtr(), map->getDataLength(), &bitmapInfo);
     auto pixelDeleter = std::unique_ptr<void, decltype(free)*>{ pixels, free };
 
     // FileMap memory is never released until application exit.
@@ -356,6 +264,7 @@ status_t BootAnimation::initTexture(FileMap* map, int* width, int* height,
     const int w = bitmapInfo.width;
     const int h = bitmapInfo.height;
 
+    GLint crop[4] = { 0, h, w, -h };
     int tw = 1 << (31 - __builtin_clz(w));
     int th = 1 << (31 - __builtin_clz(h));
     if (tw < w) tw <<= 1;
@@ -389,10 +298,7 @@ status_t BootAnimation::initTexture(FileMap* map, int* width, int* height,
             break;
     }
 
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_CROP_RECT_OES, crop);
 
     *width = w;
     *height = h;
@@ -564,9 +470,7 @@ status_t BootAnimation::readyToRun() {
     eglInitialize(display, nullptr, nullptr);
     EGLConfig config = getEglConfig(display);
     EGLSurface surface = eglCreateWindowSurface(display, config, s.get(), nullptr);
-    // Initialize egl context with client version number 2.0.
-    EGLint contextAttributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
-    EGLContext context = eglCreateContext(display, config, nullptr, contextAttributes);
+    EGLContext context = eglCreateContext(display, config, nullptr, nullptr);
     EGLint w, h;
     eglQuerySurface(display, surface, EGL_WIDTH, &w);
     eglQuerySurface(display, surface, EGL_HEIGHT, &h);
@@ -577,8 +481,8 @@ status_t BootAnimation::readyToRun() {
     mDisplay = display;
     mContext = context;
     mSurface = surface;
-    mInitWidth = mWidth = w;
-    mInitHeight = mHeight = h;
+    mWidth = w;
+    mHeight = h;
     mFlingerSurfaceControl = control;
     mFlingerSurface = s;
     mTargetInset = -1;
@@ -615,7 +519,7 @@ void BootAnimation::rotateAwayFromNaturalOrientationIfNeeded() {
 
     if (orientation == ui::ROTATION_90 || orientation == ui::ROTATION_270) {
         std::swap(mWidth, mHeight);
-        std::swap(mInitWidth, mInitHeight);
+        std::swap(mWidth, mHeight);
         mFlingerSurfaceControl->updateDefaultBufferSize(mWidth, mHeight);
     }
 
@@ -652,6 +556,11 @@ ui::Rotation BootAnimation::parseOrientationProperty() {
 void BootAnimation::projectSceneToWindow() {
     glViewport(0, 0, mWidth, mHeight);
     glScissor(0, 0, mWidth, mHeight);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrthof(0, static_cast<float>(mWidth), 0, static_cast<float>(mHeight), -1, 1);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
 }
 
 void BootAnimation::resizeSurface(int newWidth, int newHeight) {
@@ -664,7 +573,6 @@ void BootAnimation::resizeSurface(int newWidth, int newHeight) {
     eglMakeCurrent(mDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     eglDestroySurface(mDisplay, mSurface);
 
-    mFlingerSurfaceControl->updateDefaultBufferSize(newWidth, newHeight);
     const auto limitedSize = limitSurfaceSize(newWidth, newHeight);
     mWidth = limitedSize.width;
     mHeight = limitedSize.height;
@@ -745,80 +653,11 @@ void BootAnimation::findBootAnimationFile() {
     }
 }
 
-GLuint compileShader(GLenum shaderType, const GLchar *source) {
-    GLuint shader = glCreateShader(shaderType);
-    glShaderSource(shader, 1, &source, 0);
-    glCompileShader(shader);
-    GLint isCompiled = 0;
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &isCompiled);
-    if (isCompiled == GL_FALSE) {
-        SLOGE("Compile shader failed. Shader type: %d", shaderType);
-        GLint maxLength = 0;
-        glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
-        std::vector<GLchar> errorLog(maxLength);
-        glGetShaderInfoLog(shader, maxLength, &maxLength, &errorLog[0]);
-        SLOGE("Shader compilation error: %s", &errorLog[0]);
-        return 0;
-    }
-    return shader;
-}
-
-GLuint linkShader(GLuint vertexShader, GLuint fragmentShader) {
-    GLuint program = glCreateProgram();
-    glAttachShader(program, vertexShader);
-    glAttachShader(program, fragmentShader);
-    glLinkProgram(program);
-    GLint isLinked = 0;
-    glGetProgramiv(program, GL_LINK_STATUS, (int *)&isLinked);
-    if (isLinked == GL_FALSE) {
-        SLOGE("Linking shader failed. Shader handles: vert %d, frag %d",
-            vertexShader, fragmentShader);
-        return 0;
-    }
-    return program;
-}
-
-void BootAnimation::initShaders() {
-    bool dynamicColoringEnabled = mAnimation != nullptr && mAnimation->dynamicColoringEnabled;
-    GLuint vertexShader = compileShader(GL_VERTEX_SHADER, (const GLchar *)VERTEX_SHADER_SOURCE);
-    GLuint imageFragmentShader =
-        compileShader(GL_FRAGMENT_SHADER, dynamicColoringEnabled
-            ? (const GLchar *)IMAGE_FRAG_DYNAMIC_COLORING_SHADER_SOURCE
-            : (const GLchar *)IMAGE_FRAG_SHADER_SOURCE);
-    GLuint textFragmentShader =
-        compileShader(GL_FRAGMENT_SHADER, (const GLchar *)TEXT_FRAG_SHADER_SOURCE);
-
-    // Initialize image shader.
-    mImageShader = linkShader(vertexShader, imageFragmentShader);
-    GLint positionLocation = glGetAttribLocation(mImageShader, A_POSITION);
-    GLint uvLocation = glGetAttribLocation(mImageShader, A_UV);
-    mImageTextureLocation = glGetUniformLocation(mImageShader, U_TEXTURE);
-    mImageFadeLocation = glGetUniformLocation(mImageShader, U_FADE);
-    glEnableVertexAttribArray(positionLocation);
-    glVertexAttribPointer(positionLocation, 2,  GL_FLOAT, GL_FALSE, 0, quadPositions);
-    glVertexAttribPointer(uvLocation, 2, GL_FLOAT, GL_FALSE, 0, quadUVs);
-    glEnableVertexAttribArray(uvLocation);
-
-    // Initialize text shader.
-    mTextShader = linkShader(vertexShader, textFragmentShader);
-    positionLocation = glGetAttribLocation(mTextShader, A_POSITION);
-    uvLocation = glGetAttribLocation(mTextShader, A_UV);
-    mTextTextureLocation = glGetUniformLocation(mTextShader, U_TEXTURE);
-    mTextCropAreaLocation = glGetUniformLocation(mTextShader, U_CROP_AREA);
-    glEnableVertexAttribArray(positionLocation);
-    glVertexAttribPointer(positionLocation, 2,  GL_FLOAT, GL_FALSE, 0, quadPositions);
-    glVertexAttribPointer(uvLocation, 2, GL_FLOAT, GL_FALSE, 0, quadUVs);
-    glEnableVertexAttribArray(uvLocation);
-}
-
 bool BootAnimation::threadLoop() {
     bool result;
-    initShaders();
-
     // We have no bootanimation file, so we use the stock android logo
     // animation.
     if (mZipFileName.isEmpty()) {
-        ALOGD("No animation file");
         result = android();
     } else {
         result = movie();
@@ -837,8 +676,6 @@ bool BootAnimation::threadLoop() {
 }
 
 bool BootAnimation::android() {
-    glActiveTexture(GL_TEXTURE0);
-
     SLOGD("%sAnimationShownTiming start time: %" PRId64 "ms", mShuttingDown ? "Shutdown" : "Boot",
             elapsedRealtime());
     initTexture(&mAndroid[0], mAssets, "images/android-logo-mask.png");
@@ -847,16 +684,19 @@ bool BootAnimation::android() {
     mCallbacks->init({});
 
     // clear screen
+    glShadeModel(GL_FLAT);
     glDisable(GL_DITHER);
     glDisable(GL_SCISSOR_TEST);
-    glUseProgram(mImageShader);
-
     glClearColor(0,0,0,1);
     glClear(GL_COLOR_BUFFER_BIT);
     eglSwapBuffers(mDisplay, mSurface);
 
+    glEnable(GL_TEXTURE_2D);
+    glTexEnvx(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+
     // Blend state
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glTexEnvx(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 
     const nsecs_t startTime = systemTime();
     do {
@@ -879,12 +719,12 @@ bool BootAnimation::android() {
         glEnable(GL_SCISSOR_TEST);
         glDisable(GL_BLEND);
         glBindTexture(GL_TEXTURE_2D, mAndroid[1].name);
-        drawTexturedQuad(x,                 yc, mAndroid[1].w, mAndroid[1].h);
-        drawTexturedQuad(x + mAndroid[1].w, yc, mAndroid[1].w, mAndroid[1].h);
+        glDrawTexiOES(x,                 yc, 0, mAndroid[1].w, mAndroid[1].h);
+        glDrawTexiOES(x + mAndroid[1].w, yc, 0, mAndroid[1].w, mAndroid[1].h);
 
         glEnable(GL_BLEND);
         glBindTexture(GL_TEXTURE_2D, mAndroid[0].name);
-        drawTexturedQuad(xc, yc, mAndroid[0].w, mAndroid[0].h);
+        glDrawTexiOES(xc, yc, 0, mAndroid[0].w, mAndroid[0].h);
 
         EGLBoolean res = eglSwapBuffers(mDisplay, mSurface);
         if (res == EGL_FALSE)
@@ -979,20 +819,6 @@ static bool parseColor(const char str[7], float color[3]) {
     return true;
 }
 
-// Parse a color represented as a signed decimal int string.
-// E.g. "-2757722" (whose hex 2's complement is 0xFFD5EBA6).
-// If the input color string is empty, set color with values in defaultColor.
-static void parseColorDecimalString(const std::string& colorString,
-    float color[3], float defaultColor[3]) {
-    if (colorString == "") {
-        memcpy(color, defaultColor, sizeof(float) * 3);
-        return;
-    }
-    int colorInt = atoi(colorString.c_str());
-    color[0] = ((float)((colorInt >> 16) & 0xFF)) / 0xFF; // r
-    color[1] = ((float)((colorInt >> 8) & 0xFF)) / 0xFF; // g
-    color[2] = ((float)(colorInt & 0xFF)) / 0xFF; // b
-}
 
 static bool readFile(ZipFileRO* zip, const char* name, String8& outString) {
     ZipEntryRO entry = zip->findEntryByName(name);
@@ -1025,10 +851,10 @@ status_t BootAnimation::initFont(Font* font, const char* fallback) {
 
         status = initTexture(font->map, &font->texture.w, &font->texture.h);
 
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     } else if (fallback != nullptr) {
         status = initTexture(&font->texture, mAssets, fallback);
     } else {
@@ -1043,11 +869,40 @@ status_t BootAnimation::initFont(Font* font, const char* fallback) {
     return status;
 }
 
+void BootAnimation::fadeFrame(const int frameLeft, const int frameBottom, const int frameWidth,
+                              const int frameHeight, const Animation::Part& part,
+                              const int fadedFramesCount) {
+    glEnable(GL_BLEND);
+    glEnableClientState(GL_VERTEX_ARRAY);
+    glDisable(GL_TEXTURE_2D);
+    // avoid creating a hole due to mixing result alpha with GL_REPLACE texture
+    glBlendFuncSeparateOES(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+
+    const float alpha = static_cast<float>(fadedFramesCount) / part.framesToFadeCount;
+    glColor4f(part.backgroundColor[0], part.backgroundColor[1], part.backgroundColor[2], alpha);
+
+    const float frameStartX = static_cast<float>(frameLeft);
+    const float frameStartY = static_cast<float>(frameBottom);
+    const float frameEndX = frameStartX + frameWidth;
+    const float frameEndY = frameStartY + frameHeight;
+    const GLfloat frameRect[] = {
+        frameStartX, frameStartY,
+        frameEndX,   frameStartY,
+        frameEndX,   frameEndY,
+        frameStartX, frameEndY
+    };
+    glVertexPointer(2, GL_FLOAT, 0, frameRect);
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_TEXTURE_2D);
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisable(GL_BLEND);
+}
+
 void BootAnimation::drawText(const char* str, const Font& font, bool bold, int* x, int* y) {
     glEnable(GL_BLEND);  // Allow us to draw on top of the animation
     glBindTexture(GL_TEXTURE_2D, font.texture.name);
-    glUseProgram(mTextShader);
-    glUniform1i(mTextTextureLocation, 0);
 
     const int len = strlen(str);
     const int strWidth = font.char_width * len;
@@ -1063,6 +918,8 @@ void BootAnimation::drawText(const char* str, const Font& font, bool bold, int* 
         *y = mHeight + *y - font.char_height;
     }
 
+    int cropRect[4] = { 0, 0, font.char_width, -font.char_height };
+
     for (int i = 0; i < len; i++) {
         char c = str[i];
 
@@ -1074,13 +931,13 @@ void BootAnimation::drawText(const char* str, const Font& font, bool bold, int* 
         const int charPos = (c - FONT_BEGIN_CHAR);  // Position in the list of valid characters
         const int row = charPos / FONT_NUM_COLS;
         const int col = charPos % FONT_NUM_COLS;
-        // Bold fonts are expected in the second half of each row.
-        float v0 = (row + (bold ? 0.5f : 0.0f)) / FONT_NUM_ROWS;
-        float u0 = ((float)col) / FONT_NUM_COLS;
-        float v1 = v0 + 1.0f / FONT_NUM_ROWS / 2;
-        float u1 = u0 + 1.0f / FONT_NUM_COLS;
-        glUniform4f(mTextCropAreaLocation, u0, v0, u1, v1);
-        drawTexturedQuad(*x, *y, font.char_width, font.char_height);
+        cropRect[0] = col * font.char_width;  // Left of column
+        cropRect[1] = row * font.char_height * 2; // Top of row
+        // Move down to bottom of regular (one char_heigh) or bold (two char_heigh) line
+        cropRect[1] += bold ? 2 * font.char_height : font.char_height;
+        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_CROP_RECT_OES, cropRect);
+
+        glDrawTexiOES(*x, *y, 0, font.char_width, font.char_height);
 
         *x += font.char_width;
     }
@@ -1134,8 +991,6 @@ bool BootAnimation::parseAnimationDesc(Animation& animation)  {
         return false;
     }
     char const* s = desString.string();
-    std::string dynamicColoringPartName = "";
-    bool postDynamicColoring = false;
 
     // Parse the description file
     for (;;) {
@@ -1150,19 +1005,11 @@ bool BootAnimation::parseAnimationDesc(Animation& animation)  {
         int pause = 0;
         int progress = 0;
         int framesToFadeCount = 0;
-        int colorTransitionStart = 0;
-        int colorTransitionEnd = 0;
         char path[ANIM_ENTRY_NAME_MAX];
         char color[7] = "000000"; // default to black if unspecified
         char clockPos1[TEXT_POS_LEN_MAX + 1] = "";
         char clockPos2[TEXT_POS_LEN_MAX + 1] = "";
-        char dynamicColoringPartNameBuffer[ANIM_ENTRY_NAME_MAX];
         char pathType;
-        // start colors default to black if unspecified
-        char start_color_0[7] = "000000";
-        char start_color_1[7] = "000000";
-        char start_color_2[7] = "000000";
-        char start_color_3[7] = "000000";
 
         int nextReadPos;
 
@@ -1177,18 +1024,6 @@ bool BootAnimation::parseAnimationDesc(Animation& animation)  {
             } else {
               animation.progressEnabled = false;
             }
-        } else if (sscanf(l, "dynamic_colors %" STRTO(ANIM_PATH_MAX) "s #%6s #%6s #%6s #%6s %d %d",
-            dynamicColoringPartNameBuffer,
-            start_color_0, start_color_1, start_color_2, start_color_3,
-            &colorTransitionStart, &colorTransitionEnd)) {
-            animation.dynamicColoringEnabled = true;
-            parseColor(start_color_0, animation.startColors[0]);
-            parseColor(start_color_1, animation.startColors[1]);
-            parseColor(start_color_2, animation.startColors[2]);
-            parseColor(start_color_3, animation.startColors[3]);
-            animation.colorTransitionStart = colorTransitionStart;
-            animation.colorTransitionEnd = colorTransitionEnd;
-            dynamicColoringPartName = std::string(dynamicColoringPartNameBuffer);
         } else if (sscanf(l, "%c %d %d %" STRTO(ANIM_PATH_MAX) "s%n",
                           &pathType, &count, &pause, path, &nextReadPos) >= 4) {
             if (pathType == 'f') {
@@ -1201,16 +1036,6 @@ bool BootAnimation::parseAnimationDesc(Animation& animation)  {
             //       "clockPos1=%s, clockPos2=%s",
             //       pathType, count, pause, path, framesToFadeCount, color, clockPos1, clockPos2);
             Animation::Part part;
-            if (path == dynamicColoringPartName) {
-                // Part is specified to use dynamic coloring.
-                part.useDynamicColoring = true;
-                part.postDynamicColoring = false;
-                postDynamicColoring = true;
-            } else {
-                // Part does not use dynamic coloring.
-                part.useDynamicColoring = false;
-                part.postDynamicColoring =  postDynamicColoring;
-            }
             part.playUntilComplete = pathType == 'c';
             part.framesToFadeCount = framesToFadeCount;
             part.count = count;
@@ -1396,16 +1221,19 @@ bool BootAnimation::movie() {
 
     // Blend required to draw time on top of animation frames.
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glShadeModel(GL_FLAT);
     glDisable(GL_DITHER);
     glDisable(GL_SCISSOR_TEST);
     glDisable(GL_BLEND);
 
-    glEnable(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glEnable(GL_TEXTURE_2D);
+    glTexEnvx(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
     bool clockFontInitialized = false;
     if (mClockEnabled) {
         clockFontInitialized =
@@ -1418,10 +1246,6 @@ bool BootAnimation::movie() {
     if (mClockEnabled && !updateIsTimeAccurate()) {
         mTimeCheckThread = new TimeCheckThread(this);
         mTimeCheckThread->run("BootAnimation::TimeCheckThread", PRIORITY_NORMAL);
-    }
-
-    if (mAnimation->dynamicColoringEnabled) {
-        initDynamicColors();
     }
 
     playAnimation(*mAnimation);
@@ -1449,60 +1273,6 @@ bool BootAnimation::shouldStopPlayingPart(const Animation::Part& part,
         (lastDisplayedProgress == 0 || lastDisplayedProgress == 100);
 }
 
-// Linear mapping from range <a1, a2> to range <b1, b2>
-float mapLinear(float x, float a1, float a2, float b1, float b2) {
-    return b1 + ( x - a1 ) * ( b2 - b1 ) / ( a2 - a1 );
-}
-
-void BootAnimation::drawTexturedQuad(float xStart, float yStart, float width, float height) {
-    // Map coordinates from screen space to world space.
-    float x0 = mapLinear(xStart, 0, mWidth, -1, 1);
-    float y0 = mapLinear(yStart, 0, mHeight, -1, 1);
-    float x1 = mapLinear(xStart + width, 0, mWidth, -1, 1);
-    float y1 = mapLinear(yStart + height, 0, mHeight, -1, 1);
-    // Update quad vertex positions.
-    quadPositions[0] = x0;
-    quadPositions[1] = y0;
-    quadPositions[2] = x1;
-    quadPositions[3] = y0;
-    quadPositions[4] = x1;
-    quadPositions[5] = y1;
-    quadPositions[6] = x1;
-    quadPositions[7] = y1;
-    quadPositions[8] = x0;
-    quadPositions[9] = y1;
-    quadPositions[10] = x0;
-    quadPositions[11] = y0;
-    glDrawArrays(GL_TRIANGLES, 0,
-        sizeof(quadPositions) / sizeof(quadPositions[0]) / 2);
-}
-
-void BootAnimation::initDynamicColors() {
-    for (int i = 0; i < DYNAMIC_COLOR_COUNT; i++) {
-        const auto syspropName = "persist.bootanim.color" + std::to_string(i + 1);
-        const auto syspropValue = android::base::GetProperty(syspropName, "");
-        if (syspropValue != "") {
-            SLOGI("Loaded dynamic color: %s -> %s", syspropName.c_str(), syspropValue.c_str());
-            mDynamicColorsApplied = true;
-        }
-        parseColorDecimalString(syspropValue,
-            mAnimation->endColors[i], mAnimation->startColors[i]);
-    }
-    glUseProgram(mImageShader);
-    SLOGI("Dynamically coloring boot animation. Sysprops loaded? %i", mDynamicColorsApplied);
-    for (int i = 0; i < DYNAMIC_COLOR_COUNT; i++) {
-        float *startColor = mAnimation->startColors[i];
-        float *endColor = mAnimation->endColors[i];
-        glUniform3f(glGetUniformLocation(mImageShader,
-            (U_START_COLOR_PREFIX + std::to_string(i)).c_str()),
-            startColor[0], startColor[1], startColor[2]);
-        glUniform3f(glGetUniformLocation(mImageShader,
-            (U_END_COLOR_PREFIX + std::to_string(i)).c_str()),
-            endColor[0], endColor[1], endColor[2]);
-    }
-    mImageColorProgressLocation = glGetUniformLocation(mImageShader, U_COLOR_PROGRESS);
-}
-
 bool BootAnimation::playAnimation(const Animation& animation) {
     const size_t pcount = animation.parts.size();
     nsecs_t frameDuration = s2ns(1) / animation.fps;
@@ -1512,11 +1282,10 @@ bool BootAnimation::playAnimation(const Animation& animation) {
 
     int fadedFramesCount = 0;
     int lastDisplayedProgress = 0;
-    int colorTransitionStart = animation.colorTransitionStart;
-    int colorTransitionEnd = animation.colorTransitionEnd;
     for (size_t i=0 ; i<pcount ; i++) {
         const Animation::Part& part(animation.parts[i]);
         const size_t fcount = part.frames.size();
+        glBindTexture(GL_TEXTURE_2D, 0);
 
         // Handle animation package
         if (part.animation != nullptr) {
@@ -1530,23 +1299,6 @@ bool BootAnimation::playAnimation(const Animation& animation) {
         for (int r=0 ; !part.count || r<part.count || fadedFramesCount > 0 ; r++) {
             if (shouldStopPlayingPart(part, fadedFramesCount, lastDisplayedProgress)) break;
 
-            // It's possible that the sysprops were not loaded yet at this boot phase.
-            // If that's the case, then we should keep trying until they are available.
-            if (animation.dynamicColoringEnabled && !mDynamicColorsApplied
-                && (part.useDynamicColoring || part.postDynamicColoring)) {
-                SLOGD("Trying to load dynamic color sysprops.");
-                initDynamicColors();
-                if (mDynamicColorsApplied) {
-                    // Sysprops were loaded. Next step is to adjust the animation if we loaded
-                    // the colors after the animation should have started.
-                    const int transitionLength = colorTransitionEnd - colorTransitionStart;
-                    if (part.postDynamicColoring) {
-                        colorTransitionStart = 0;
-                        colorTransitionEnd = fmin(transitionLength, fcount - 1);
-                    }
-                }
-            }
-
             mCallbacks->playPart(i, part, r);
 
             glClearColor(
@@ -1554,10 +1306,6 @@ bool BootAnimation::playAnimation(const Animation& animation) {
                     part.backgroundColor[1],
                     part.backgroundColor[2],
                     1.0f);
-
-            ALOGD("Playing files = %s/%s, Requested repeat = %d, playUntilComplete = %s",
-                    animation.fileName.string(), part.path.string(), part.count,
-                    part.playUntilComplete ? "true" : "false");
 
             // For the last animation, if we have progress indicator from
             // the system, display it.
@@ -1568,24 +1316,10 @@ bool BootAnimation::playAnimation(const Animation& animation) {
             for (size_t j=0 ; j<fcount ; j++) {
                 if (shouldStopPlayingPart(part, fadedFramesCount, lastDisplayedProgress)) break;
 
-                // Color progress is
-                // - the animation progress, normalized from
-                //   [colorTransitionStart,colorTransitionEnd] to [0, 1] for the dynamic coloring
-                //   part.
-                // - 0 for parts that come before,
-                // - 1 for parts that come after.
-                float colorProgress = part.useDynamicColoring
-                    ? fmin(fmax(
-                        ((float)j - colorTransitionStart) /
-                            fmax(colorTransitionEnd - colorTransitionStart, 1.0f), 0.0f), 1.0f)
-                    : (part.postDynamicColoring ? 1 : 0);
-
                 processDisplayEvents();
 
-                const double ratio_w = static_cast<double>(mWidth) / mInitWidth;
-                const double ratio_h = static_cast<double>(mHeight) / mInitHeight;
-                const int animationX = (mWidth - animation.width * ratio_w) / 2;
-                const int animationY = (mHeight - animation.height * ratio_h) / 2;
+                const int animationX = (mWidth - animation.width) / 2;
+                const int animationY = (mHeight - animation.height) / 2;
 
                 const Animation::Frame& frame(part.frames[j]);
                 nsecs_t lastFrame = systemTime();
@@ -1593,42 +1327,44 @@ bool BootAnimation::playAnimation(const Animation& animation) {
                 if (r > 0) {
                     glBindTexture(GL_TEXTURE_2D, frame.tid);
                 } else {
-                    glGenTextures(1, &frame.tid);
-                    glBindTexture(GL_TEXTURE_2D, frame.tid);
+                    if (part.count != 1) {
+                        glGenTextures(1, &frame.tid);
+                        glBindTexture(GL_TEXTURE_2D, frame.tid);
+                        glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                        glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                    }
                     int w, h;
-                    // Set decoding option to alpha unpremultiplied so that the R, G, B channels
-                    // of transparent pixels are preserved.
-                    initTexture(frame.map, &w, &h, false /* don't premultiply alpha */);
+                    initTexture(frame.map, &w, &h);
                 }
 
-                const int trimWidth = frame.trimWidth * ratio_w;
-                const int trimHeight = frame.trimHeight * ratio_h;
-                const int trimX = frame.trimX * ratio_w;
-                const int trimY = frame.trimY * ratio_h;
-                const int xc = animationX + trimX;
-                const int yc = animationY + trimY;
-                glClear(GL_COLOR_BUFFER_BIT);
+                const int xc = animationX + frame.trimX;
+                const int yc = animationY + frame.trimY;
+                Region clearReg(Rect(mWidth, mHeight));
+                clearReg.subtractSelf(Rect(xc, yc, xc+frame.trimWidth, yc+frame.trimHeight));
+                if (!clearReg.isEmpty()) {
+                    Region::const_iterator head(clearReg.begin());
+                    Region::const_iterator tail(clearReg.end());
+                    glEnable(GL_SCISSOR_TEST);
+                    while (head != tail) {
+                        const Rect& r2(*head++);
+                        glScissor(r2.left, mHeight - r2.bottom, r2.width(), r2.height());
+                        glClear(GL_COLOR_BUFFER_BIT);
+                    }
+                    glDisable(GL_SCISSOR_TEST);
+                }
                 // specify the y center as ceiling((mHeight - frame.trimHeight) / 2)
                 // which is equivalent to mHeight - (yc + frame.trimHeight)
-                const int frameDrawY = mHeight - (yc + trimHeight);
+                const int frameDrawY = mHeight - (yc + frame.trimHeight);
+                glDrawTexiOES(xc, frameDrawY, 0, frame.trimWidth, frame.trimHeight);
 
-                float fade = 0;
                 // if the part hasn't been stopped yet then continue fading if necessary
                 if (exitPending() && part.hasFadingPhase()) {
-                    fade = static_cast<float>(++fadedFramesCount) / part.framesToFadeCount;
+                    fadeFrame(xc, frameDrawY, frame.trimWidth, frame.trimHeight, part,
+                              ++fadedFramesCount);
                     if (fadedFramesCount >= part.framesToFadeCount) {
                         fadedFramesCount = MAX_FADED_FRAMES_COUNT; // no more fading
                     }
                 }
-                glUseProgram(mImageShader);
-                glUniform1i(mImageTextureLocation, 0);
-                glUniform1f(mImageFadeLocation, fade);
-                if (animation.dynamicColoringEnabled) {
-                    glUniform1f(mImageColorProgressLocation, colorProgress);
-                }
-                glEnable(GL_BLEND);
-                drawTexturedQuad(xc, frameDrawY, trimWidth, trimHeight);
-                glDisable(GL_BLEND);
 
                 if (mClockEnabled && mTimeIsAccurate && validClock(part)) {
                     drawClock(animation.clockFont, part.clockPosX, part.clockPosY);
@@ -1696,9 +1432,6 @@ bool BootAnimation::playAnimation(const Animation& animation) {
             }
         }
     }
-
-    ALOGD("%sAnimationShownTiming End time: %" PRId64 "ms", mShuttingDown ? "Shutdown" : "Boot",
-            elapsedRealtime());
 
     return true;
 }
@@ -1774,8 +1507,6 @@ BootAnimation::Animation* BootAnimation::loadAnimation(const String8& fn) {
             fn.string(), strerror(errno));
         return nullptr;
     }
-
-    ALOGD("%s is loaded successfully", fn.string());
 
     Animation *animation =  new Animation;
     animation->fileName = fn;

--- a/cmds/bootanimation/BootAnimation.h
+++ b/cmds/bootanimation/BootAnimation.h
@@ -33,7 +33,7 @@
 #include <ui/Rotation.h>
 
 #include <EGL/egl.h>
-#include <GLES2/gl2.h>
+#include <GLES/gl.h>
 
 namespace android {
 
@@ -55,7 +55,7 @@ public:
     };
 
     struct Font {
-        FileMap* map = nullptr;
+        FileMap* map;
         Texture texture;
         int char_width;
         int char_height;
@@ -64,7 +64,7 @@ public:
     struct Animation {
         struct Frame {
             String8 name;
-            FileMap* map = nullptr;
+            FileMap* map;
             int trimX;
             int trimY;
             int trimWidth;
@@ -92,10 +92,6 @@ public:
             uint8_t* audioData;
             int audioLength;
             Animation* animation;
-            // Controls if dynamic coloring is enabled for this part.
-            bool useDynamicColoring = false;
-            // Defines if this part is played after the dynamic coloring part.
-            bool postDynamicColoring = false;
 
             bool hasFadingPhase() const {
                 return !playUntilComplete && framesToFadeCount > 0;
@@ -111,12 +107,6 @@ public:
         ZipFileRO* zip;
         Font clockFont;
         Font progressFont;
-         // Controls if dynamic coloring is enabled for the whole animation.
-        bool dynamicColoringEnabled = false;
-        int colorTransitionStart = 0; // Start frame of dynamic color transition.
-        int colorTransitionEnd = 0; // End frame of dynamic color transition.
-        float startColors[4][3]; // Start colors of dynamic color transition.
-        float endColors[4][3];   // End colors of dynamic color transition.
     };
 
     // All callbacks will be called from this class's internal thread.
@@ -175,12 +165,9 @@ private:
     int displayEventCallback(int fd, int events, void* data);
     void processDisplayEvents();
 
-    status_t initTexture(Texture* texture, AssetManager& asset, const char* name,
-        bool premultiplyAlpha = true);
-    status_t initTexture(FileMap* map, int* width, int* height,
-        bool premultiplyAlpha = true);
+    status_t initTexture(Texture* texture, AssetManager& asset, const char* name);
+    status_t initTexture(FileMap* map, int* width, int* height);
     status_t initFont(Font* font, const char* fallback);
-    void initShaders();
     bool android();
     bool movie();
     void drawText(const char* str, const Font& font, bool bold, int* x, int* y);
@@ -188,7 +175,6 @@ private:
     void drawProgress(int percent, const Font& font, const int xPos, const int yPos);
     void fadeFrame(int frameLeft, int frameBottom, int frameWidth, int frameHeight,
                    const Animation::Part& part, int fadedFramesCount);
-    void drawTexturedQuad(float xStart, float yStart, float width, float height);
     bool validClock(const Animation::Part& part);
     Animation* loadAnimation(const String8&);
     bool playAnimation(const Animation&);
@@ -210,15 +196,12 @@ private:
     void checkExit();
 
     void handleViewport(nsecs_t timestep);
-    void initDynamicColors();
 
     sp<SurfaceComposerClient>       mSession;
     AssetManager mAssets;
     Texture     mAndroid[2];
     int         mWidth;
     int         mHeight;
-    int         mInitWidth;
-    int         mInitHeight;
     int         mMaxWidth = 0;
     int         mMaxHeight = 0;
     int         mCurrentInset;
@@ -234,19 +217,11 @@ private:
     bool        mTimeIsAccurate;
     bool        mTimeFormat12Hour;
     bool        mShuttingDown;
-    bool        mDynamicColorsApplied = false;
     String8     mZipFileName;
     SortedVector<String8> mLoadedFiles;
     sp<TimeCheckThread> mTimeCheckThread = nullptr;
     sp<Callbacks> mCallbacks;
     Animation* mAnimation = nullptr;
-    GLuint mImageShader;
-    GLuint mTextShader;
-    GLuint mImageFadeLocation;
-    GLuint mImageTextureLocation;
-    GLuint mTextCropAreaLocation;
-    GLuint mTextTextureLocation;
-    GLuint mImageColorProgressLocation;
 };
 
 // ---------------------------------------------------------------------------

--- a/cmds/bootanimation/OWNERS
+++ b/cmds/bootanimation/OWNERS
@@ -1,3 +1,0 @@
-dupin@google.com
-shanh@google.com
-jreck@google.com


### PR DESCRIPTION
…loring

    Revert "Fix AOSP boot animation black screen issue."

    This reverts commit bfd2d3ce722a4626b4cdb8e7977ac46239c89ce1.

    Revert "Fixes boot animation not appearing issue on Oriole."

    This reverts commit 81846bad1a5de1920f74ffe7c58d1207aa998e47.

    Revert "Support rendering white pixels."

    This reverts commit 488ff7459cd752e718ec4aa1f6ea0dd28aa91078.

    Revert "Move boot color sysprop parsing to after loading zips."

    This reverts commit a1f7a71c2df15cef04e79f6c20f126e81b49c839.

    Revert "Update boot animation owners"

    This reverts commit 7d4f45d4644e722e9fc938a28ce73af36cd4a629.

    Revert "Revert "Revert "Revert "Revert "Implement dynamic colors for boot animation."""""

    This reverts commit 89965006af67c848cf531955180353811f8fd1bb.

    Revert "Revert "Revert "Migrate boot animation from GLES 1.0 to GLES2.0."""

    This reverts commit dd7ed60de0efbc682ee98605faa128fa39bb99dc.

    Change-Id: I03b8e8d3a1bc502f1d3e12a8b3577ff488e40529

    Revert "Add additional logs for bootanimation"

    This reverts commit 9ef19b85cbc8ccc55ef8607c9420967443b20461.

    Revert "Reload color sysprops after failing"

    This reverts commit cd25684a0cdd0f44312013527171002e0f104f7c.

    Revert "bootanimation: correct logo position and size after resolution changed"

    This reverts commit 85b339fb246768d8ec34375463e4bfe8b968eaaf.

    Revert "Try to load colors more frequently"

    This reverts commit bfd1812fcbcada2dfb1bc9846c0b131658ec2b85.

Change-Id: I8bde368dd16bd225e46c6399fab75a1e0cc1a7e5